### PR TITLE
use dirname(@__FILE__) instead of Pkg.dir

### DIFF
--- a/src/DynamicalBilliards.jl
+++ b/src/DynamicalBilliards.jl
@@ -37,7 +37,7 @@ end
 Enable plotting for the package DynamicalBilliards.jl
 """
 function enableplotting()
-  dir = joinpath(Pkg.dir("DynamicalBilliards"), "src", "plotting")
+  dir = joinpath(dirname(@__FILE__), "plotting")
   for f in readdir(dir)
     include(joinpath(dir, f))
   end


### PR DESCRIPTION
this allows installing and loading the package from elsewhere