### PR TITLE
Fix bdplot_control_actions! by removing old MakieLayout qualifier

### DIFF
--- a/ext/premade_anim_functions.jl
+++ b/ext/premade_anim_functions.jl
@@ -105,7 +105,7 @@ function bdplot_control_actions!(
 
     # Selecting a line and making new particles
     ax = content(fig[1,1][1,1])
-    MakieLayout.deactivate_interaction!(ax, :rectanglezoom)
+    deactivate_interaction!(ax, :rectanglezoom)
     sline = select_line(ax.scene; color = JULIADYNAMICS_COLORS[1])
     dx = 0.001 # TODO: make this a keyword
     ω0 = DynamicalBilliards.ismagnetic(ps0[][1]) ? ps0[][1].ω : nothing


### PR DESCRIPTION
This has been removed from Makie for a while. It doesn't show up copying examples from `billiards_visualizations.jl` because the line isn't run for `CairoMakie`.

It might be useful to have tests for the plotting or run some of the docs examples as doctests.